### PR TITLE
add support for apc mini mk2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # apc-pro-py
-Interface with an AKAI APC Mini and MIDI Mix MIDI controllers using python
+Interface with Midi controllers using python
+
+# Supported controllers
+* AKAI APC Mini
+* AKAI APC Mini mk2
+* MIDI Mix
 
 Requires [mido](https://github.com/mido/mido) and asyncio *(will be automatically be installed with pip)*
 
 # Install:
 To install, simply run:
 ```
-pip3 install -U git+https://github.com/secretowo/apc-mini-py 
+pip3 install -U git+https://github.com/dhoessl/apc-mini-py 
 ```
 
 # Usage:

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Interface with Midi controllers using python
 * AKAI APC Mini mk2
 * MIDI Mix
 
-Requires [mido](https://github.com/mido/mido) and asyncio *(will be automatically be installed with pip)*
 
 # Install:
+Requires [mido](https://github.com/mido/mido) and asyncio *(will be automatically be installed with pip)*
+
 To install, simply run:
 ```
 pip3 install -U git+https://github.com/dhoessl/apc-mini-py 

--- a/akai_pro_py/APCminimkii.py
+++ b/akai_pro_py/APCminimkii.py
@@ -1,0 +1,533 @@
+from .base_controller import Controller
+import mido
+import time
+
+from . import errors
+
+
+class InvalidGridButton(errors.ControllerError):
+    def __init__(self, *args):
+        if args:
+            self.controller = args[0]
+            self.midi_port = args[1]
+            if isinstance(args[2], tuple):
+                self.x, self.y = args[2]
+                self.button_id = None
+            else:
+                self.x, self.y = (None, None)
+                self.button_id = args[2]
+        else:
+            self.controller = None
+            self.midi_port = None
+            self.x, self.y = (None, None)
+
+    def __str__(self):
+        if self.controller and self.midi_port and self.x and self.y:
+            return f"Grid Button {self.x},{self.y} does not exist on " \
+                    f"controller {self.controller.name}, MIDI port: " \
+                    f"{self.midi_port.name}"
+
+        elif self.controller and self.midi_port and self.button_id:
+            return f"Grid Button {self.button_id} does not exist on " \
+                    f"controller {self.controller.name}, MIDI port: " \
+                    f"{self.midi_port.name}"
+
+        elif not self.controller and not self.midi_port and self.x and self.y:
+            return f"Grid Button {self.x},{self.y} does not exist on " \
+                    f"controller"
+
+        elif not self.controller and not self.midi_port and self.button_id:
+            return f"Grid Button {self.button_id} does not exist on controller"
+
+        else:
+            return "Generic invalid Grid Button error"
+
+
+class InvalidFader(errors.ControllerError):
+    def __init__(self, *args):
+        if args:
+            self.controller = args[0]
+            self.midi_port = args[1]
+            self.fader_id = args[2]
+        else:
+            self.controller = None
+            self.midi_port = None
+            self.fader_id = None
+
+    def __str__(self):
+        if self.controller and self.midi_port and self.fader_id:
+            return f"Fader {self.fader_id} does not exist on controller " \
+                    f"{self.controller.name}, MIDI port: {self.midi_port.name}"
+
+        elif not self.controller and not self.midi_port and self.button_id:
+            return f"Fader {self.fader_id} does not exist on controller"
+
+        else:
+            return "Generic invalid Fader error"
+
+
+class InvalidLowerButton(errors.ControllerError):
+    def __init__(self, *args):
+        if args:
+            self.controller = args[0]
+            self.midi_port = args[1]
+            self.button_id = args[2]
+        else:
+            self.controller = None
+            self.midi_port = None
+            self.button_id = None
+
+    def __str__(self):
+        if self.controller and self.midi_port and self.button_id:
+            return f"Lower Button button {self.button_id} does not exist on " \
+                    f"controller {self.controller.name}, MIDI port: " \
+                    f"{self.midi_port.name}"
+
+        elif not self.controller and not self.midi_port and self.button_id:
+            return f"Lower Button button {self.button_id} does not exist on " \
+                    f"controller"
+
+        else:
+            return "Generic invalid Lower Button button error"
+
+
+class InvalidSideButton(errors.ControllerError):
+    def __init__(self, *args):
+        if args:
+            self.controller = args[0]
+            self.midi_port = args[1]
+            self.button_id = args[2]
+        else:
+            self.controller = None
+            self.midi_port = None
+            self.button_id = None
+
+    def __str__(self):
+        if self.controller and self.midi_port and self.button_id:
+            return f"Side Button button {self.button_id} does not exist on" \
+                    f"controller {self.controller.name}, MIDI port: " \
+                    f"{self.midi_port.name}"
+
+        elif not self.controller and not self.midi_port and self.button_id:
+            return f"Side Button button {self.button_id} does not exist on " \
+                    f"controller"
+
+        else:
+            return "Generic invalid Side Button button error"
+
+
+class InvalidButtonColour(errors.ControllerError):
+    def __init__(self, *args):
+        if args:
+            self.controller = args[0]
+            self.midi_port = args[1]
+            self.button = args[2]
+        else:
+            self.controller = None
+            self.midi_port = None
+            self.button = None
+
+    def __str__(self):
+        if isinstance(self.button, APCMinimkii.GridButton):
+            return "Invalid button colour for Grid buttons, valid options " \
+                    "are 0-127," + ",".join(APCMinimkii.GridColours.keys())
+
+        elif isinstance(self.button, APCMinimkii.LowerButton):
+            return "Invalid button colour for Lower button, valid options " \
+                    "are 0-127," \
+                    + ",".join(APCMinimkii.LowerButtonColours.keys())
+
+        elif isinstance(self.button, APCMinimkii.SideButton):
+            return "Invalid button colour for Side button, valid options " \
+                    "are 0-127," \
+                    + ",".join(APCMinimkii.LowerButtonColours.keys())
+
+        else:
+            return "Generic invalid button colour error"
+
+
+class InvalidButtonEffect(errors.ControllerError):
+    def __init__(self, *args):
+        if args:
+            self.controller = args[0]
+            self.midi_port = args[1]
+            self.button = args[2]
+        else:
+            self.controller = None
+            self.midi_port = None
+            self.button = None
+
+    def __str__(self):
+        if isinstance(self.button, APCMinimkii.GridButton):
+            return "Invalid button colour for Grid buttons, valid options " \
+                    + ",".join(APCMinimkii.GridEffects.keys()) + "," \
+                    + ",".join(str(x) for x in range(18))
+
+        else:
+            return "Generic invalid button colour error"
+
+
+class APCMinimkii(Controller):
+    GridMapping = [
+        [0, 8, 16, 24, 32, 40, 48, 56],
+        [1, 9, 17, 25, 33, 41, 49, 57],
+        [2, 10, 18, 26, 34, 42, 50, 58],
+        [3, 11, 19, 27, 35, 43, 51, 59],
+        [4, 12, 20, 28, 36, 44, 52, 60],
+        [5, 13, 21, 29, 37, 45, 53, 61],
+        [6, 14, 22, 30, 38, 46, 54, 62],
+        [7, 15, 23, 31, 39, 47, 55, 63]
+    ]  # The mapping of an XY coordinate to the MIDI note for the button grid
+
+    GridColours = {
+        "off": 0,
+        "white": 3,
+        "red": 5,
+        "orange": 9,
+        "yellow": 13,
+        "green": 17,
+        "lime": 21,
+        "lime2": 25,
+        "aqua green": 29,
+        "cyan": 33,
+        "sky blue": 36,
+        "blue": 37,
+        "blue2": 41,
+        "blue3": 45,
+        "magenta": 53,
+        "pink": 57,
+        "vivid green": 73
+    }  # Dict of all available colours for the grid
+
+    GridEffects = {
+        "brightness_10": 0,
+        "brightness_25": 1,
+        "brightness_50": 2,
+        "brightness_65": 3,
+        "brightness_75": 4,
+        "brightness_90": 5,
+        "brightness_100": 6,
+        "bright": 6,
+        "dimm": 2,
+        "pulse_1_16": 7,
+        "pulse_1_8": 8,
+        "pulse_1_4": 9,
+        "pulse_1_2": 10,
+        "pulse": 10,
+        "blink_1_24": 11,
+        "blink_1_16": 12,
+        "blink_1_8": 13,
+        "blink_1_4": 14,
+        "blink_1_2": 15,
+        "blink": 15
+    }  # Channel Values for colour effects on the grid
+
+    # Mapping of faders to their number indexed from 0
+    FaderMapping = [48, 49, 50, 51, 52, 53, 54, 55, 56]
+
+    # Mapping of side buttons from top to bottom, indexed from 0
+    SideButtonMapping = [112, 113, 114, 115, 116, 117, 118, 119]
+
+    SideButtonColours = {
+        "on": 1,
+        "off": 0,
+        "green": 1,
+        "green_blinking": 2
+    }  # Dict of all colours for the side buttons
+
+    # Mapping of lower buttons from left to right, indexed from 0
+    LowerButtonMapping = [100, 101, 102, 103, 104, 105, 106, 107]
+
+    LowerButtonColours = {
+        "on": 1,
+        "off": 0,
+        "red": 1,
+        "red_blinking": 2
+    }  # Dict of all colours for the lower buttons
+
+    ShiftButtonMapping = [122]
+
+    def __init__(self, midi_in=None, midi_out=None):
+        super().__init__(midi_in, midi_out)
+        self.name = "Akai APC Mini MK 2"  # Name of the device
+        self.gridbuttons = APCMinimkii.GridButtons(self)
+        self.sidebuttons = APCMinimkii.SideButtons(self)
+        self.lowerbuttons = APCMinimkii.LowerButtons(self)
+
+    def reset(self):
+        """Turns off all LEDs"""
+        # Build range
+        all_leds = [int(x) for x in range(64)]
+        all_leds += APCMinimkii.SideButtonMapping
+        all_leds += APCMinimkii.LowerButtonMapping
+        for i in all_leds:
+            self.midi_out.send(mido.Message("note_on", note=i, velocity=0))
+            time.sleep(0.005)
+
+    def product_detect(self, event):
+        try:
+            if event.data[2] != 6:
+                raise errors.ControllerIdentificationError(
+                    self, self.midi_in, "Controller did not identify!"
+                )
+
+            if event.data[4] != 71:
+                raise errors.ControllerIdentificationError(
+                    "MIDI device is not an Akai device!"
+                )
+
+            if event.data[5] != 79:
+                raise errors.ControllerIdentificationError(
+                    "MIDI device is not an Akai APC Mini"
+                )
+        except (AttributeError, IndexError):
+            raise errors.ControllerIdentificationError(
+                self, self.midi_in, "MIDI device failed to identify"
+            )
+        self.setup_in_progress = False
+        return True
+
+    def pre_event_dispatch(self, event):
+        if self.event_dispatch is None:
+            # Ignore if a dispatch event is not set with the on_event decorator
+            return
+
+        if event.type == "control_change":  # Event is a fader change
+            fader = APCMinimkii.Fader(
+                self,
+                APCMinimkii.Fader.get_fader_id_from_number(event.control),
+                event.value
+            )
+            self.event_dispatch(fader)
+
+        elif event.type == "note_on" or event.type == "note_off":
+            # Event is a button press
+            state = True
+            if event.note in range(64):  # Button grid
+                if event.type == 'note_off':
+                    state = False
+                button = APCMinimkii.GridButton(
+                    self,
+                    *APCMinimkii.GridButton.get_xy_from_button_num(event.note),
+                    state
+                )
+                self.event_dispatch(button)
+
+            elif event.note in APCMinimkii.SideButtonMapping:  # Side buttons
+                if event.type == 'note_off':
+                    state = False
+                button = APCMinimkii.SideButton(
+                    self,
+                    APCMinimkii.SideButton.get_button_id_from_button_num(event.note),  # noqa: E501
+                    state
+                )
+                self.event_dispatch(button)
+
+            elif event.note in APCMinimkii.LowerButtonMapping:  # Lower buttons
+                if event.type == 'note_off':
+                    state = False
+                button = APCMinimkii.LowerButton(
+                    self,
+                    APCMinimkii.LowerButton.get_button_id_from_button_num(event.note),  # noqa: E501
+                    state
+                )
+                self.event_dispatch(button)
+
+            elif event.note in APCMinimkii.ShiftButtonMapping:
+                if event.type == 'note_off':
+                    state = False
+                button = APCMinimkii.ShiftButton(self, state)
+                self.event_dispatch(button)
+
+    class GridButtons:  # All the grid buttons
+        def __init__(self, controller):
+            self.controller = controller
+
+        def set_led(self, x, y, colour, effect):
+            """Sets an LED on the button grid"""
+            APCMinimkii.GridButton(self.controller, x, y).set_led(colour, effect)  # noqa: E501
+
+    class GridButton:  # A specific grid button
+        def __init__(self, controller, x: int, y: int, state: bool = False):
+            self.controller = controller
+            self.x = x
+            self.y = y
+            self.state = state
+
+        @staticmethod
+        def get_xy_from_button_num(button_num):
+            for column in APCMinimkii.GridMapping:
+                x = APCMinimkii.GridMapping.index(column)
+                if button_num in column:
+                    return x, APCMinimkii.GridMapping[x].index(button_num)
+                else:
+                    continue
+            raise InvalidGridButton(None, None, button_num)
+
+        def set_led(self, colour, effect):
+            """Sets this specific button's LED to be the colour given"""
+            if not isinstance(colour, int):
+                # if colour is given as string check APCMinimkii.GridColours
+                # for the string and set the correct value
+                if colour not in APCMinimkii.GridColours:
+                    raise InvalidButtonColour(
+                        self.controller,
+                        self.controller.midi_in,
+                        self
+                    )
+                colour = APCMinimkii.GridColours[colour]
+            if not isinstance(effect, int):
+                # if effect is given as string check APCMinimkii.GridEffects
+                # for the string and set the correct value
+                if effect not in APCMinimkii.GridEffects:
+                    raise InvalidButtonEffect(
+                        self.controller,
+                        self.controller.midi_in,
+                        self
+                    )
+                effect = APCMinimkii.GridEffects[effect]
+            if colour not in range(128):
+                # Check if colour value is inside of the allowed 128 values
+                raise InvalidButtonColour(
+                    self.controller, self.controller.midi_in, self
+                )
+            if effect not in range(16):
+                # Check if effect value is inside of the allowed 16 values
+                raise InvalidButtonEffect(
+                    self.controller, self.controller.midi_in, self
+                )
+            try:  # Try to set the led
+                self.controller.midi_out.send(
+                    mido.Message(
+                        "note_on",
+                        note=APCMinimkii.GridMapping[self.x][self.y],
+                        velocity=colour,
+                        channel=effect
+                    )
+                )
+            except IndexError:
+                raise InvalidGridButton(
+                    self.controller, self.controller.midi_in,
+                    (self.x, self.y)
+                )
+
+    class Fader:  # A single fader
+        def __init__(self, controller, fader_id, value):
+            self.controller = controller
+            self.fader_id = fader_id
+            self.value = value
+
+        @staticmethod
+        def get_fader_id_from_number(fader_num):
+            try:
+                return APCMinimkii.FaderMapping.index(fader_num)
+            except IndexError:
+                raise InvalidFader(None, None, fader_num)
+
+    class SideButtons:  # All the side buttons
+        def __init__(self, controller):
+            self.controller = controller
+
+        def set_led(self, button_id, colour):
+            """Sets an LED on the side buttons"""
+            APCMinimkii.SideButton(self.controller, button_id).set_led(colour)
+
+    class SideButton:  # A specific side button
+        def __init__(self, controller, button_id: int, state: bool = False):
+            self.controller = controller
+            self.button_id = button_id
+            self.state = state
+
+        @staticmethod
+        def get_button_id_from_button_num(button_num):
+            return APCMinimkii.SideButtonMapping.index(button_num)
+
+        def set_led(self, colour):
+            """Sets this specific button's LED to be the colour given"""
+            if not isinstance(colour, int):
+                if colour not in APCMinimkii.SideButtonColours:
+                    raise InvalidButtonColour(
+                        self.controller,
+                        self.controller.midi_in,
+                        self
+                    )
+                colour = APCMinimkii.SideButtonColours[colour]
+            if colour not in range(128):
+                # Check if colour is a valid value
+                raise InvalidButtonColour(
+                    self.controller,
+                    self.controller.midi_in,
+                    self
+                )
+            try:  # Try to send the event
+                self.controller.midi_out.send(
+                    mido.Message(
+                        "note_on",
+                        note=APCMinimkii.SideButtonMapping[self.button_id],
+                        velocity=colour
+                    )
+                )
+            except IndexError:
+                raise InvalidSideButton(
+                    self.controller,
+                    self.controller.midi_in,
+                    self.button_id
+                )
+
+    class LowerButtons:  # All the lower buttons
+        def __init__(self, controller):
+            self.controller = controller
+
+        def set_led(self, button_id, colour):
+            """Sets an LED on the lower buttons"""
+            APCMinimkii.LowerButton(self.controller, button_id).set_led(colour)
+
+    class LowerButton:  # A specific side button
+        def __init__(self, controller, button_id: int, state: bool = False):
+            self.controller = controller
+            self.button_id = button_id
+            self.state = state
+
+        @staticmethod
+        def get_button_id_from_button_num(button_num):
+            try:
+                return APCMinimkii.LowerButtonMapping.index(button_num)
+            except IndexError:
+                raise InvalidLowerButton(None, None, button_num)
+
+        def set_led(self, colour):
+            """Sets this specific button's LED to be the colour given"""
+            if not isinstance(colour, int):
+                if colour not in APCMinimkii.LowerButtonColours:
+                    raise InvalidButtonColour(
+                        self.controller,
+                        self.controller.midi_in,
+                        self
+                    )
+                colour = APCMinimkii.LowerButtonColours[colour]
+            if colour not in range(128):
+                # Check if colour is a valid value
+                raise InvalidButtonColour(
+                    self.controller,
+                    self.controller.midi_in,
+                    self
+                )
+            try:
+                self.controller.midi_out.send(
+                    mido.Message(
+                        "note_on",
+                        note=APCMinimkii.LowerButtonMapping[self.button_id],  # noqa: E501
+                        velocity=colour
+                    )
+                )
+            except IndexError:
+                raise InvalidLowerButton(
+                    self.controller,
+                    self.controller.midi_in,
+                    self.button_id
+                )
+
+    class ShiftButton:  # The shift button
+        def __init__(self, controller, state: bool = False):
+            self.controller = controller
+            self.state = state

--- a/akai_pro_py/APCminimkii.py
+++ b/akai_pro_py/APCminimkii.py
@@ -354,7 +354,7 @@ class APCMinimkii(Controller):
 
         def reset_all_leds(self):
             for button in range(64):
-                self.midi_out.send(
+                self.controller.midi_out.send(
                     mido.Message("note_on", note=button, velocity=0)
                 )
 

--- a/akai_pro_py/APCminimkii.py
+++ b/akai_pro_py/APCminimkii.py
@@ -254,7 +254,7 @@ class APCMinimkii(Controller):
         self.sidebuttons = APCMinimkii.SideButtons(self)
         self.lowerbuttons = APCMinimkii.LowerButtons(self)
 
-    def reset(self):
+    def reset(self, fast=False):
         """Turns off all LEDs"""
         # Build range
         all_leds = [int(x) for x in range(64)]
@@ -262,7 +262,8 @@ class APCMinimkii(Controller):
         all_leds += APCMinimkii.LowerButtonMapping
         for i in all_leds:
             self.midi_out.send(mido.Message("note_on", note=i, velocity=0))
-            time.sleep(0.005)
+            if not fast:
+                time.sleep(0.005)
 
     def product_detect(self, event):
         try:
@@ -346,6 +347,16 @@ class APCMinimkii(Controller):
         def set_led(self, x, y, colour, effect):
             """Sets an LED on the button grid"""
             APCMinimkii.GridButton(self.controller, x, y).set_led(colour, effect)  # noqa: E501
+
+        def reset_led(self, x, y):
+            """ Turns of an LED on the button grid """
+            APCMinimkii.GridButton(self.controller, x, y).set_led(0, 0)  # noqa: E501
+
+        def reset_all_leds(self):
+            for button in range(64):
+                self.midi_out.send(
+                    mido.Message("note_on", note=button, velocity=0)
+                )
 
     class GridButton:  # A specific grid button
         def __init__(self, controller, x: int, y: int, state: bool = False):
@@ -432,6 +443,15 @@ class APCMinimkii(Controller):
             """Sets an LED on the side buttons"""
             APCMinimkii.SideButton(self.controller, button_id).set_led(colour)
 
+        def reset_led(self, button_id):
+            """Turns of an LED on the side buttons"""
+            APCMinimkii.SideButton(self.controller, button_id).set_led(0)
+
+        def reset_all_leds(self):
+            """Turns of all LEDs on the side buttons"""
+            for button in range(len(APCMinimkii.SideButtonMapping)):
+                self.reset_led(button)
+
     class SideButton:  # A specific side button
         def __init__(self, controller, button_id: int, state: bool = False):
             self.controller = controller
@@ -481,6 +501,15 @@ class APCMinimkii(Controller):
         def set_led(self, button_id, colour):
             """Sets an LED on the lower buttons"""
             APCMinimkii.LowerButton(self.controller, button_id).set_led(colour)
+
+        def reset_led(self, button_id):
+            """Turns of an LED on the lower buttons"""
+            APCMinimkii.LowerButton(self.controller, button_id).set_led(0)
+
+        def reset_all_leds(self):
+            """Turns of all LEDs on the lower buttons"""
+            for button in range(len(APCMinimkii.LowerButtonMapping)):
+                self.reset_led(button)
 
     class LowerButton:  # A specific side button
         def __init__(self, controller, button_id: int, state: bool = False):

--- a/akai_pro_py/controllers.py
+++ b/akai_pro_py/controllers.py
@@ -5,3 +5,4 @@ import time
 from .base_controller import Controller
 from .MIDIMix import MIDIMix
 from .APCmini import APCMini
+from .APCminimkii import APCMinimkii

--- a/examples/APCMinimkii/leds_and_buttons.py
+++ b/examples/APCMinimkii/leds_and_buttons.py
@@ -1,0 +1,78 @@
+from akai_pro_py import controllers
+from scipy.interpolate import interp1d
+from rtmidi import MidiOut
+from re import match
+
+
+def get_controller(search) -> str:
+    for port in MidiOut().get_ports():
+        matching = match(search, port)
+        if matching:
+            return matching.group()
+
+
+apc = controllers.APCMinimkii(
+    get_controller(r"^APC.*?Contr.*$"),
+    get_controller(r"^APC.*?Contr.*$")
+)
+
+apc.reset()  # turn off all leds
+
+# Creates a map from the 7 bit values of MIDI to a 3 bit value for display
+midi_to_led = interp1d([0, 127], [0, 7])
+
+
+# Defines this function for recieving button presses/fader changes
+@apc.on_event
+def on_control_event(event):
+    # Checks if the event is a grid button press
+    if isinstance(event, controllers.APCMinimkii.GridButton):
+        if event.state:
+            # Turn the button red when pressed
+            apc.gridbuttons.set_led(event.x, event.y, "red", "bright")
+            print("button " + str(event.x) + "x" + str(event.y) + " pressed")
+        else:
+            # and off when not pressed
+            apc.gridbuttons.set_led(event.x, event.y, "off", 6)
+            print("button released")
+    elif isinstance(event, controllers.APCMinimkii.SideButton):
+        if event.state:
+            apc.sidebuttons.set_led(event.button_id, 2)
+        else:
+            apc.sidebuttons.set_led(event.button_id, 0)
+    elif isinstance(event, controllers.APCMinimkii.LowerButton):
+        if event.state:
+            print("turn on on button " + str(event.button_id))
+            apc.lowerbuttons.set_led(event.button_id, 1)
+        else:
+            print("turn off on button " + str(event.button_id))
+            apc.lowerbuttons.set_led(event.button_id, 0)
+    elif isinstance(event, controllers.APCMinimkii.ShiftButton):
+        apc.reset()
+    elif isinstance(event, controllers.APCMinimkii.Fader):
+        # Ignore fader ID 8 (the master fader)
+        if event.fader_id == 8:
+            return
+        # Map the MIDI value (0,127) to 3 bit (0,7)
+        value = int(midi_to_led(event.value))
+        print(event.value)
+        print(value)
+        if event.value == 0:  # If the value is 0 (fader at minimum)
+            for i in range(0, 8):
+                # Set all LEDs in the column to off
+                apc.gridbuttons.set_led(event.fader_id, i, "off", 0)
+        else:
+            # Go through all the LEDs that should be on
+            for i in range(0, value + 1):
+                # and set them to green
+                if event.value == 127:
+                    apc.gridbuttons.set_led(event.fader_id, i, "green", "blink")
+                else:
+                    apc.gridbuttons.set_led(event.fader_id, i, "blue", "pulse")
+            # Go through all the LEDs that should be off
+            for i in range(value + 1, 8):
+                # and set them to off
+                apc.gridbuttons.set_led(event.fader_id, i, "off", 0)
+
+
+apc.start()

--- a/examples/APCMinimkii/leds_and_buttons.py
+++ b/examples/APCMinimkii/leds_and_buttons.py
@@ -59,7 +59,7 @@ def on_control_event(event):
             apc.lowerbuttons.set_led(event.button_id, 0)
     elif isinstance(event, controllers.APCMinimkii.ShiftButton):
         # apc.reset()
-        apc.gridbuttons.reset_all()
+        apc.gridbuttons.reset_all_leds()
     elif isinstance(event, controllers.APCMinimkii.Fader):
         # Ignore fader ID 8 (the master fader)
         if event.fader_id == 8:

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from setuptools import setup
 
 setup(
     name='akai_pro_py',
-    version='0.2.3',
+    version='0.3.1',
     description='A simple library for interfacing with the Akai Professional series of MIDI controllers',
-    url='https://github.com/Secretowo/apc-mini-py',
-    author='Secret and Lewis L. Foster',
-    author_email='Secret <unknown>, Lewis L. Foster <lewis@sniff122.tech>',
+    url='https://github.com/dhoessl/apc-mini-py',
+    author='Secret and Lewis L. Foster, Dominic Hößl',
+    author_email='Secret <unknown>, Lewis L. Foster <lewis@sniff122.tech>, Dominic Hößl <dominichoessl@gmail.com>',
     license='',
     packages=['akai_pro_py'],
     install_requires=['mido',


### PR DESCRIPTION
I wanted to use APC mini mk2 as a controller for some program i wrote.
Since my knowledge of midi was not that great, i searched for a existing Interface using python for the APC mini mk2.
It seems like there was nothing out there. I checked out this project but the APCmini.py interface did not work for me.

Now i got a little bit of understanding for how the midi messaging works and i implemented the support for the APC mini mk2 with the base of the APCmini.py

Since i reused a lot of this code i guess its best to give something back and share it with other people in need.

I tweaked some Classes and Functions and set everything in APCminimkii.py to a width of 80 chars. I hope you do not mind my linting.

In my example i reused the code from existing examples, but tweaked the Fader display and added the new functions of the APC mini mk2.